### PR TITLE
fix(pied-pier): don't call alive charmed person if alone

### DIFF
--- a/src/modules/game/providers/services/game-play/game-play.service.ts
+++ b/src/modules/game/providers/services/game-play/game-play.service.ts
@@ -147,6 +147,16 @@ export class GamePlayService {
     return isEnabled && electedAt.turn === currentTurn && electedAt.phaseName === currentGamePhaseAsDayOrNight;
   }
 
+  private isCharmedGamePlaySuitableForCurrentPhase(game: CreateGameDto | Game): boolean {
+    if (game instanceof CreateGameDto || !this.isPiedPiperGamePlaySuitableForCurrentPhase(game)) {
+      return false;
+    }
+    const charmedPlayers = getPlayersWithActiveAttributeName(game, "charmed");
+    const aliveCharmedPlayers = charmedPlayers.filter(player => player.isAlive);
+
+    return aliveCharmedPlayers.length > 1;
+  }
+
   private async isLoversGamePlaySuitableForCurrentPhase(game: CreateGameDto | Game, gamePlay: GamePlay): Promise<boolean> {
     if (game instanceof CreateGameDto) {
       return false;
@@ -223,7 +233,7 @@ export class GamePlayService {
     const specificGroupMethods: Record<PlayerGroup, (game: CreateGameDto | Game, gamePlay: GamePlay) => Promise<boolean> | boolean> = {
       survivors: async() => this.isSurvivorsGamePlaySuitableForCurrentPhase(game, gamePlay),
       lovers: async() => this.isLoversGamePlaySuitableForCurrentPhase(game, gamePlay),
-      charmed: () => this.isPiedPiperGamePlaySuitableForCurrentPhase(game),
+      charmed: () => this.isCharmedGamePlaySuitableForCurrentPhase(game),
       werewolves: () => game instanceof CreateGameDto || getGroupOfPlayers(game, source).some(werewolf => werewolf.isAlive),
       villagers: () => false,
     };

--- a/tests/acceptance/features/game/data/game-options/pied-piper-charms-one-person-per-night-option.json
+++ b/tests/acceptance/features/game/data/game-options/pied-piper-charms-one-person-per-night-option.json
@@ -1,0 +1,7 @@
+{
+  "roles": {
+    "piedPiper": {
+      "charmedPeopleCountPerNight": 1
+    }
+  }
+}

--- a/tests/acceptance/features/game/features/role/pied-piper.feature
+++ b/tests/acceptance/features/game/features/role/pied-piper.feature
@@ -443,3 +443,42 @@ Feature: 🪈 Pied Piper role
     When the survivors bury dead bodies
     Then the game's current play should be werewolves to eat
     And the game's status should be playing
+
+  Scenario: 🪈 Pied Piper charms only one person by night, so the charmed person is not call because he's alone
+
+    Given a created game with options described in file no-sheriff-option.json, pied-piper-charms-one-person-per-night-option.json and with the following players
+      | name    | role       |
+      | Antoine | pied-piper |
+      | Olivia  | werewolf   |
+      | JB      | villager   |
+      | Thomas  | villager   |
+      | Dad     | villager   |
+    Then the game's current play should be werewolves to eat
+
+    When the werewolves eat the player named Thomas
+    Then the player named Thomas should have the active eaten from werewolves attribute
+    And the game's current play should be pied-piper to charm
+
+    When the pied piper charms the following players
+      | name |
+      | JB   |
+    Then the game's current play should be survivors to bury-dead-bodies
+
+    When the survivors bury dead bodies
+    Then the game's current play should be survivors to vote
+
+    When the player or group skips his turn
+    Then the game's current play should be werewolves to eat
+
+    When the werewolves eat the player named Antoine
+    Then the player named Antoine should have the active eaten from werewolves attribute
+    And the game's current play should be pied-piper to charm
+
+    When the pied piper charms the following players
+      | name |
+      | Dad  |
+    Then the game's current play should be charmed to meet-each-other
+    And the game's current play should be played by the following players
+      | name |
+      | JB   |
+      | Dad  |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new game mechanic where the "Pied Piper" role can charm specific players each night.

- **Bug Fixes**
  - Ensured the game checks if charmed gameplay is suitable for the current phase.

- **Tests**
  - Added and updated test cases to reflect new "Pied Piper" charm mechanics and validate gameplay changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->