### PR TITLE
feat(pied-piper): charmed people revealed game option

### DIFF
--- a/src/modules/game/constants/game-options/game-options.constants.ts
+++ b/src/modules/game/constants/game-options/game-options.constants.ts
@@ -52,6 +52,7 @@ const DEFAULT_GAME_OPTIONS: ReadonlyDeep<GameOptions> = {
     piedPiper: {
       charmedPeopleCountPerNight: 2,
       isPowerlessOnWerewolvesSide: true,
+      areCharmedPeopleRevealed: false,
     },
     scandalmonger: { markPenalty: 2 },
     witch: { doesKnowWerewolvesTargets: true },

--- a/src/modules/game/dto/create-game/create-game-options/create-roles-game-options/create-pied-piper-game-options.dto.ts
+++ b/src/modules/game/dto/create-game/create-game-options/create-roles-game-options/create-pied-piper-game-options.dto.ts
@@ -22,6 +22,14 @@ class CreatePiedPiperGameOptionsDto {
   @IsOptional()
   @IsBoolean()
   public isPowerlessOnWerewolvesSide: boolean = PIED_PIPER_GAME_OPTIONS_FIELDS_SPECS.isPowerlessOnWerewolvesSide.default;
+
+  @ApiProperty({
+    ...PIED_PIPER_GAME_OPTIONS_API_PROPERTIES.areCharmedPeopleRevealed,
+    required: false,
+  } as ApiPropertyOptions)
+  @IsOptional()
+  @IsBoolean()
+  public areCharmedPeopleRevealed: boolean = PIED_PIPER_GAME_OPTIONS_FIELDS_SPECS.areCharmedPeopleRevealed.default;
 }
 
 export { CreatePiedPiperGameOptionsDto };

--- a/src/modules/game/schemas/game-options/roles-game-options/pied-piper-game-options/pied-piper-game-options.schema.constants.ts
+++ b/src/modules/game/schemas/game-options/roles-game-options/pied-piper-game-options/pied-piper-game-options.schema.constants.ts
@@ -18,6 +18,10 @@ const PIED_PIPER_GAME_OPTIONS_FIELDS_SPECS = {
     required: true,
     default: DEFAULT_GAME_OPTIONS.roles.piedPiper.isPowerlessOnWerewolvesSide,
   },
+  areCharmedPeopleRevealed: {
+    required: true,
+    default: DEFAULT_GAME_OPTIONS.roles.piedPiper.areCharmedPeopleRevealed,
+  },
 } as const satisfies Record<keyof PiedPiperGameOptions, MongoosePropOptions>;
 
 const PIED_PIPER_GAME_OPTIONS_API_PROPERTIES: ReadonlyDeep<Record<keyof PiedPiperGameOptions, ApiPropertyOptions>> = {
@@ -28,6 +32,10 @@ const PIED_PIPER_GAME_OPTIONS_API_PROPERTIES: ReadonlyDeep<Record<keyof PiedPipe
   isPowerlessOnWerewolvesSide: {
     description: "If set to `true`, `pied piper` will be `powerless` if he joins the werewolves side",
     ...convertMongoosePropOptionsToApiPropertyOptions(PIED_PIPER_GAME_OPTIONS_FIELDS_SPECS.isPowerlessOnWerewolvesSide),
+  },
+  areCharmedPeopleRevealed: {
+    description: "If set to `true`, `charmed` people by the `pied piper` will be revealed to other players each time the `pied piper` plays",
+    ...convertMongoosePropOptionsToApiPropertyOptions(PIED_PIPER_GAME_OPTIONS_FIELDS_SPECS.areCharmedPeopleRevealed),
   },
 };
 

--- a/src/modules/game/schemas/game-options/roles-game-options/pied-piper-game-options/pied-piper-game-options.schema.ts
+++ b/src/modules/game/schemas/game-options/roles-game-options/pied-piper-game-options/pied-piper-game-options.schema.ts
@@ -20,6 +20,11 @@ class PiedPiperGameOptions {
   @Prop(PIED_PIPER_GAME_OPTIONS_FIELDS_SPECS.isPowerlessOnWerewolvesSide)
   @Expose()
   public isPowerlessOnWerewolvesSide: boolean;
+
+  @ApiProperty(PIED_PIPER_GAME_OPTIONS_API_PROPERTIES.areCharmedPeopleRevealed as ApiPropertyOptions)
+  @Prop(PIED_PIPER_GAME_OPTIONS_FIELDS_SPECS.areCharmedPeopleRevealed)
+  @Expose()
+  public areCharmedPeopleRevealed: boolean;
 }
 
 const PIED_PIPER_GAME_OPTIONS_SCHEMA = SchemaFactory.createForClass(PiedPiperGameOptions);

--- a/tests/e2e/specs/modules/game/controllers/game.controller.e2e-spec.ts
+++ b/tests/e2e/specs/modules/game/controllers/game.controller.e2e-spec.ts
@@ -1028,6 +1028,7 @@ describe("Game Controller", () => {
           piedPiper: {
             charmedPeopleCountPerNight: 1,
             isPowerlessOnWerewolvesSide: false,
+            areCharmedPeopleRevealed: true,
           },
           scandalmonger: { markPenalty: 5 },
           witch: { doesKnowWerewolvesTargets: false },

--- a/tests/factories/game/dto/create-game/create-game-options/create-roles-game-options/create-roles-game-options.dto.factory.ts
+++ b/tests/factories/game/dto/create-game/create-game-options/create-roles-game-options/create-roles-game-options.dto.factory.ts
@@ -69,6 +69,7 @@ function createFakeCreatePiedPiperGameOptionsDto(piedPiperGameOptions: Partial<C
   return plainToInstance(CreatePiedPiperGameOptionsDto, {
     charmedPeopleCountPerNight: piedPiperGameOptions.charmedPeopleCountPerNight ?? faker.number.int({ min: 1, max: 5 }),
     isPowerlessOnWerewolvesSide: piedPiperGameOptions.isPowerlessOnWerewolvesSide ?? faker.datatype.boolean(),
+    areCharmedPeopleRevealed: piedPiperGameOptions.areCharmedPeopleRevealed ?? faker.datatype.boolean(),
     ...override,
   }, DEFAULT_PLAIN_TO_INSTANCE_OPTIONS);
 }

--- a/tests/factories/game/schemas/game-options/game-roles-options/game-roles-options.schema.factory.ts
+++ b/tests/factories/game/schemas/game-options/game-roles-options/game-roles-options.schema.factory.ts
@@ -66,6 +66,7 @@ function createFakePiedPiperGameOptions(piedPiperGameOptions: Partial<PiedPiperG
   return plainToInstance(PiedPiperGameOptions, {
     charmedPeopleCountPerNight: piedPiperGameOptions.charmedPeopleCountPerNight ?? faker.number.int({ min: 1, max: 5 }),
     isPowerlessOnWerewolvesSide: piedPiperGameOptions.isPowerlessOnWerewolvesSide ?? faker.datatype.boolean(),
+    areCharmedPeopleRevealed: piedPiperGameOptions.areCharmedPeopleRevealed ?? faker.datatype.boolean(),
     ...override,
   }, DEFAULT_PLAIN_TO_INSTANCE_OPTIONS);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new game option for the Pied Piper role: "Revealed Charmed People". This allows players to configure whether charmed people are revealed to others each time the Pied Piper charms someone.

- **Tests**
  - Added test cases to cover the new "Revealed Charmed People" option for the Pied Piper role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->