### PR TITLE
feat(votes): votes duration in game options

### DIFF
--- a/src/modules/game/constants/game-options/game-options.constants.ts
+++ b/src/modules/game/constants/game-options/game-options.constants.ts
@@ -4,7 +4,10 @@ import type { GameOptions } from "@/modules/game/schemas/game-options/game-optio
 
 const DEFAULT_GAME_OPTIONS: ReadonlyDeep<GameOptions> = {
   composition: { isHidden: false },
-  votes: { canBeSkipped: true },
+  votes: {
+    canBeSkipped: true,
+    duration: 180,
+  },
   roles: {
     areRevealedOnDeath: true,
     doSkipCallIfNoTarget: false,

--- a/src/modules/game/dto/create-game/create-game-options/create-votes-game-options/create-votes-game-options.dto.ts
+++ b/src/modules/game/dto/create-game/create-game-options/create-votes-game-options/create-votes-game-options.dto.ts
@@ -1,7 +1,7 @@
 import type { ApiPropertyOptions } from "@nestjs/swagger";
 import { ApiProperty } from "@nestjs/swagger";
 import { Type } from "class-transformer";
-import { IsBoolean, IsOptional } from "class-validator";
+import { IsBoolean, IsInt, IsOptional, Max, Min } from "class-validator";
 
 import { VOTES_GAME_OPTIONS_API_PROPERTIES, VOTES_GAME_OPTIONS_FIELDS_SPECS } from "@/modules/game/schemas/game-options/votes-game-options/votes-game-options.schema.constants";
 
@@ -14,6 +14,17 @@ class CreateVotesGameOptionsDto {
   @IsOptional()
   @IsBoolean()
   public canBeSkipped: boolean = VOTES_GAME_OPTIONS_FIELDS_SPECS.canBeSkipped.default;
+
+  @ApiProperty({
+    ...VOTES_GAME_OPTIONS_API_PROPERTIES.duration,
+    required: false,
+  } as ApiPropertyOptions)
+  @Type(() => Number)
+  @IsOptional()
+  @IsInt()
+  @Min(VOTES_GAME_OPTIONS_FIELDS_SPECS.duration.min)
+  @Max(VOTES_GAME_OPTIONS_FIELDS_SPECS.duration.max)
+  public duration: number = VOTES_GAME_OPTIONS_FIELDS_SPECS.duration.default;
 }
 
 export { CreateVotesGameOptionsDto };

--- a/src/modules/game/schemas/game-options/votes-game-options/votes-game-options.schema.constants.ts
+++ b/src/modules/game/schemas/game-options/votes-game-options/votes-game-options.schema.constants.ts
@@ -12,12 +12,23 @@ const VOTES_GAME_OPTIONS_FIELDS_SPECS = {
     required: true,
     default: DEFAULT_GAME_OPTIONS.votes.canBeSkipped,
   },
+  duration: {
+    required: true,
+    default: DEFAULT_GAME_OPTIONS.votes.duration,
+    min: 10,
+    max: 600,
+  },
 } as const satisfies Record<keyof VotesGameOptions, MongoosePropOptions>;
 
 const VOTES_GAME_OPTIONS_API_PROPERTIES: ReadonlyDeep<Record<keyof VotesGameOptions, ApiPropertyOptions>> = {
   canBeSkipped: {
     description: "If set to `true`, players are not obliged to vote. There won't be any death if votes are skipped. Sheriff election nor votes because of the angel presence can't be skipped",
     ...convertMongoosePropOptionsToApiPropertyOptions(VOTES_GAME_OPTIONS_FIELDS_SPECS.canBeSkipped),
+  },
+
+  duration: {
+    description: "Duration of the votes play in seconds. It doesn't lock in the votes, it only helps the game master to know when to stop the votes play. Vote play can be submitted before the end of the duration.",
+    ...convertMongoosePropOptionsToApiPropertyOptions(VOTES_GAME_OPTIONS_FIELDS_SPECS.duration),
   },
 };
 

--- a/src/modules/game/schemas/game-options/votes-game-options/votes-game-options.schema.ts
+++ b/src/modules/game/schemas/game-options/votes-game-options/votes-game-options.schema.ts
@@ -15,6 +15,11 @@ class VotesGameOptions {
   @Prop(VOTES_GAME_OPTIONS_FIELDS_SPECS.canBeSkipped)
   @Expose()
   public canBeSkipped: boolean;
+
+  @ApiProperty(VOTES_GAME_OPTIONS_API_PROPERTIES.duration as ApiPropertyOptions)
+  @Prop(VOTES_GAME_OPTIONS_FIELDS_SPECS.duration)
+  @Expose()
+  public duration: number;
 }
 
 const VOTES_GAME_OPTIONS_SCHEMA = SchemaFactory.createForClass(VotesGameOptions);

--- a/tests/e2e/specs/modules/game/controllers/game.controller.e2e-spec.ts
+++ b/tests/e2e/specs/modules/game/controllers/game.controller.e2e-spec.ts
@@ -981,6 +981,10 @@ describe("Game Controller", () => {
 
     it(`should create game with different options when called with options specified and some omitted.`, async() => {
       const options: Partial<GameOptions> = {
+        votes: {
+          canBeSkipped: false,
+          duration: 10,
+        },
         roles: {
           areRevealedOnDeath: false,
           doSkipCallIfNoTarget: true,
@@ -1043,7 +1047,6 @@ describe("Game Controller", () => {
       const expectedOptions = createFakeGameOptionsDto({
         ...options,
         composition: createFakeCompositionGameOptions({ isHidden: DEFAULT_GAME_OPTIONS.composition.isHidden }),
-        votes: createFakeVotesGameOptions({ canBeSkipped: DEFAULT_GAME_OPTIONS.votes.canBeSkipped }),
       });
       const response = await app.inject({
         method: "POST",

--- a/tests/factories/game/dto/create-game/create-game-options/create-votes-game-options/create-votes-game-options.dto.factory.ts
+++ b/tests/factories/game/dto/create-game/create-game-options/create-votes-game-options/create-votes-game-options.dto.factory.ts
@@ -8,6 +8,7 @@ import { DEFAULT_PLAIN_TO_INSTANCE_OPTIONS } from "@/shared/validation/constants
 function createFakeVotesGameOptionsDto(createVotesGameOptionsDto: Partial<CreateVotesGameOptionsDto> = {}, override: object = {}): CreateVotesGameOptionsDto {
   return plainToInstance(CreateVotesGameOptionsDto, {
     canBeSkipped: createVotesGameOptionsDto.canBeSkipped ?? faker.datatype.boolean(),
+    duration: createVotesGameOptionsDto.duration ?? faker.number.int({ min: 10, max: 600 }),
     ...override,
   }, DEFAULT_PLAIN_TO_INSTANCE_OPTIONS);
 }

--- a/tests/factories/game/schemas/game-options/votes-game-options.schema.factory.ts
+++ b/tests/factories/game/schemas/game-options/votes-game-options.schema.factory.ts
@@ -8,6 +8,7 @@ import { DEFAULT_PLAIN_TO_INSTANCE_OPTIONS } from "@/shared/validation/constants
 function createFakeVotesGameOptions(createVotesGameOptions: Partial<VotesGameOptions> = {}, override: object = {}): VotesGameOptions {
   return plainToInstance(VotesGameOptions, {
     canBeSkipped: createVotesGameOptions.canBeSkipped ?? faker.datatype.boolean(),
+    duration: createVotesGameOptions.duration ?? faker.number.int({ min: 10, max: 600 }),
     ...override,
   }, DEFAULT_PLAIN_TO_INSTANCE_OPTIONS);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `duration` property to the game options, allowing users to specify the duration of the voting period (default: 180 seconds, range: 10-600 seconds).

- **Bug Fixes**
  - Enhanced validation for the `duration` property to ensure proper range and integer values.

- **Tests**
  - Updated tests to include the new `duration` property in various game options scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->