### PR TITLE
feat(werewolves): werewolves can eat each other game option

### DIFF
--- a/src/modules/game/constants/game-options/game-options.constants.ts
+++ b/src/modules/game/constants/game-options/game-options.constants.ts
@@ -20,6 +20,7 @@ const DEFAULT_GAME_OPTIONS: ReadonlyDeep<GameOptions> = {
       hasDoubledVote: true,
       mustSettleTieInVotes: true,
     },
+    werewolf: { canEatEachOther: false },
     bigBadWolf: { isPowerlessIfWerewolfDies: true },
     whiteWerewolf: { wakingUpInterval: 2 },
     seer: {

--- a/src/modules/game/dto/create-game/create-game-options/create-roles-game-options/create-roles-game-options.dto.ts
+++ b/src/modules/game/dto/create-game/create-game-options/create-roles-game-options/create-roles-game-options.dto.ts
@@ -1,3 +1,4 @@
+import { CreateWerewolfGameOptionsDto } from "@/modules/game/dto/create-game/create-game-options/create-roles-game-options/create-werewolf-game-options.dto";
 import type { ApiPropertyOptions } from "@nestjs/swagger";
 import { ApiProperty } from "@nestjs/swagger";
 import { Type } from "class-transformer";
@@ -52,6 +53,15 @@ class CreateRolesGameOptionsDto {
   @Type(() => CreateSheriffGameOptionsDto)
   @ValidateNested()
   public sheriff: CreateSheriffGameOptionsDto = new CreateSheriffGameOptionsDto();
+
+  @ApiProperty({
+    ...ROLES_GAME_OPTIONS_API_PROPERTIES.werewolf,
+    required: false,
+  } as ApiPropertyOptions)
+  @IsOptional()
+  @Type(() => CreateWerewolfGameOptionsDto)
+  @ValidateNested()
+  public werewolf: CreateWerewolfGameOptionsDto = new CreateWerewolfGameOptionsDto();
 
   @ApiProperty({
     ...ROLES_GAME_OPTIONS_API_PROPERTIES.bigBadWolf,

--- a/src/modules/game/dto/create-game/create-game-options/create-roles-game-options/create-werewolf-game-options.dto.ts
+++ b/src/modules/game/dto/create-game/create-game-options/create-roles-game-options/create-werewolf-game-options.dto.ts
@@ -1,0 +1,16 @@
+import { WEREWOLF_GAME_OPTIONS_API_PROPERTIES, WEREWOLF_GAME_OPTIONS_FIELDS_SPECS } from "@/modules/game/schemas/game-options/roles-game-options/werewolf-game-options/werewolf-game-options.schema.constants";
+import type { ApiPropertyOptions } from "@nestjs/swagger";
+import { ApiProperty } from "@nestjs/swagger";
+import { IsBoolean, IsOptional } from "class-validator";
+
+class CreateWerewolfGameOptionsDto {
+  @ApiProperty({
+    ...WEREWOLF_GAME_OPTIONS_API_PROPERTIES.canEatEachOther,
+    required: false,
+  } as ApiPropertyOptions)
+  @IsOptional()
+  @IsBoolean()
+  public canEatEachOther: boolean = WEREWOLF_GAME_OPTIONS_FIELDS_SPECS.canEatEachOther.default;
+}
+
+export { CreateWerewolfGameOptionsDto };

--- a/src/modules/game/helpers/game.helpers.ts
+++ b/src/modules/game/helpers/game.helpers.ts
@@ -106,8 +106,22 @@ function getEligiblePiedPiperTargets(game: Game): Player[] {
 }
 
 function getEligibleWerewolvesTargets(game: Game): Player[] {
-  return game.players.filter(player => player.isAlive && player.side.current === "villagers" &&
-    !doesPlayerHaveActiveAttributeWithName(player, "eaten", game));
+  const { canEatEachOther: canWerewolvesEatEachOther } = game.options.roles.werewolf;
+  const aliveWerewolfSidePlayers = getAliveWerewolfSidedPlayers(game);
+  const isWerewolfAlone = aliveWerewolfSidePlayers.length === 1;
+
+  return game.players.filter(player => {
+    const isPlayerNotAlreadyEaten = !doesPlayerHaveActiveAttributeWithName(player, "eaten", game);
+    const isPlayerVillagerSide = player.side.current === "villagers";
+
+    return player.isAlive && (canWerewolvesEatEachOther && !isWerewolfAlone || isPlayerVillagerSide) && isPlayerNotAlreadyEaten;
+  });
+}
+
+function getEligibleBigBadWolfTargets(game: Game): Player[] {
+  const eligibleWerewolvesTargets = getEligibleWerewolvesTargets(game);
+
+  return eligibleWerewolvesTargets.filter(player => player.role.current !== "big-bad-wolf");
 }
 
 function getEligibleWhiteWerewolfTargets(game: Game): Player[] {
@@ -234,6 +248,7 @@ export {
   getAliveWerewolfSidedPlayers,
   getEligiblePiedPiperTargets,
   getEligibleWerewolvesTargets,
+  getEligibleBigBadWolfTargets,
   getEligibleWhiteWerewolfTargets,
   getEligibleCupidTargets,
   getGroupOfPlayers,

--- a/src/modules/game/providers/services/game-play/game-play-augmenter.service.ts
+++ b/src/modules/game/providers/services/game-play/game-play-augmenter.service.ts
@@ -5,7 +5,7 @@ import { doesGamePlayHaveCause } from "@/modules/game/helpers/game-play/game-pla
 import { DeadPlayer } from "@/modules/game/schemas/player/dead-player.schema";
 import { createGamePlaySourceInteraction } from "@/modules/game/helpers/game-play/game-play-source/game-play-source-interaction/game-play-source-interaction.factory";
 import { createGamePlay } from "@/modules/game/helpers/game-play/game-play.factory";
-import { getAlivePlayers, getAllowedToVotePlayers, getEligibleCupidTargets, getEligiblePiedPiperTargets, getEligibleWerewolvesTargets, getEligibleWhiteWerewolfTargets, getGroupOfPlayers, getPlayersWithActiveAttributeName, getPlayersWithCurrentRole, getPlayerWithCurrentRole, isGameSourceGroup, isGameSourceRole } from "@/modules/game/helpers/game.helpers";
+import { getAlivePlayers, getAllowedToVotePlayers, getEligibleBigBadWolfTargets, getEligibleCupidTargets, getEligiblePiedPiperTargets, getEligibleWerewolvesTargets, getEligibleWhiteWerewolfTargets, getGroupOfPlayers, getPlayersWithActiveAttributeName, getPlayersWithCurrentRole, getPlayerWithCurrentRole, isGameSourceGroup, isGameSourceRole } from "@/modules/game/helpers/game.helpers";
 import { doesPlayerHaveActiveAttributeWithName, doesPlayerHaveActiveAttributeWithNameAndSource } from "@/modules/game/helpers/player/player-attribute/player-attribute.helpers";
 import { createPlayer } from "@/modules/game/helpers/player/player.factory";
 import { isPlayerAliveAndPowerful } from "@/modules/game/helpers/player/player.helpers";
@@ -214,11 +214,11 @@ export class GamePlayAugmenterService {
   }
 
   private getWerewolvesGamePlaySourceInteractions(game: Game): GamePlaySourceInteraction[] {
-    const aliveVillagerSidedPlayers = getEligibleWerewolvesTargets(game);
+    const eligibleWerewolvesTargets = getEligibleWerewolvesTargets(game);
     const interaction = createGamePlaySourceInteraction({
       source: "werewolves",
       type: "eat",
-      eligibleTargets: aliveVillagerSidedPlayers,
+      eligibleTargets: eligibleWerewolvesTargets,
       boundaries: { min: 1, max: 1 },
     });
 
@@ -226,14 +226,14 @@ export class GamePlayAugmenterService {
   }
 
   private getBigBadWolfGamePlaySourceInteractions(game: Game): GamePlaySourceInteraction[] {
-    const eligibleWerewolvesTargets = getEligibleWerewolvesTargets(game);
-    if (eligibleWerewolvesTargets.length === 0) {
+    const eligibleBigBadWolfTargets = getEligibleBigBadWolfTargets(game);
+    if (eligibleBigBadWolfTargets.length === 0) {
       return [];
     }
     const interaction = createGamePlaySourceInteraction({
       source: "big-bad-wolf",
       type: "eat",
-      eligibleTargets: eligibleWerewolvesTargets,
+      eligibleTargets: eligibleBigBadWolfTargets,
       boundaries: { min: 1, max: 1 },
     });
 
@@ -475,7 +475,7 @@ export class GamePlayAugmenterService {
   }
 
   private canBigBadWolfSkipGamePlay(game: Game): boolean {
-    const leftToEatByWerewolvesPlayers = getEligibleWerewolvesTargets(game);
+    const leftToEatByWerewolvesPlayers = getEligibleBigBadWolfTargets(game);
 
     return leftToEatByWerewolvesPlayers.length === 0;
   }

--- a/src/modules/game/schemas/game-options/roles-game-options/roles-game-options.schema.constants.ts
+++ b/src/modules/game/schemas/game-options/roles-game-options/roles-game-options.schema.constants.ts
@@ -1,3 +1,4 @@
+import { WEREWOLF_GAME_OPTIONS_SCHEMA } from "@/modules/game/schemas/game-options/roles-game-options/werewolf-game-options/werewolf-game-options.schema";
 import type { ApiPropertyOptions } from "@nestjs/swagger";
 import type { ReadonlyDeep } from "type-fest";
 
@@ -42,6 +43,11 @@ const ROLES_GAME_OPTIONS_FIELDS_SPECS = {
     required: true,
     type: SHERIFF_GAME_OPTIONS_SCHEMA,
     default: DEFAULT_GAME_OPTIONS.roles.sheriff,
+  },
+  werewolf: {
+    required: true,
+    type: WEREWOLF_GAME_OPTIONS_SCHEMA,
+    default: DEFAULT_GAME_OPTIONS.roles.werewolf,
   },
   bigBadWolf: {
     required: true,
@@ -162,6 +168,10 @@ const ROLES_GAME_OPTIONS_API_PROPERTIES: ReadonlyDeep<Record<keyof RolesGameOpti
   sheriff: {
     description: "Game `sheriff` role's options.",
     ...convertMongoosePropOptionsToApiPropertyOptions(ROLES_GAME_OPTIONS_FIELDS_SPECS.sheriff),
+  },
+  werewolf: {
+    description: "Game `werewolf` role's or `werewolves` group options.",
+    ...convertMongoosePropOptionsToApiPropertyOptions(ROLES_GAME_OPTIONS_FIELDS_SPECS.werewolf),
   },
   bigBadWolf: {
     description: "Game `big bad wolf` role's options.",

--- a/src/modules/game/schemas/game-options/roles-game-options/roles-game-options.schema.ts
+++ b/src/modules/game/schemas/game-options/roles-game-options/roles-game-options.schema.ts
@@ -1,3 +1,4 @@
+import { WerewolfGameOptions } from "@/modules/game/schemas/game-options/roles-game-options/werewolf-game-options/werewolf-game-options.schema";
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
 import type { ApiPropertyOptions } from "@nestjs/swagger";
 import { ApiProperty } from "@nestjs/swagger";
@@ -48,6 +49,12 @@ class RolesGameOptions {
   @Type(() => SheriffGameOptions)
   @Expose()
   public sheriff: SheriffGameOptions;
+
+  @ApiProperty(ROLES_GAME_OPTIONS_API_PROPERTIES.werewolf as ApiPropertyOptions)
+  @Prop(ROLES_GAME_OPTIONS_FIELDS_SPECS.werewolf)
+  @Type(() => WerewolfGameOptions)
+  @Expose()
+  public werewolf: WerewolfGameOptions;
 
   @ApiProperty(ROLES_GAME_OPTIONS_API_PROPERTIES.bigBadWolf as ApiPropertyOptions)
   @Prop(ROLES_GAME_OPTIONS_FIELDS_SPECS.bigBadWolf)

--- a/src/modules/game/schemas/game-options/roles-game-options/werewolf-game-options/werewolf-game-options.schema.constants.ts
+++ b/src/modules/game/schemas/game-options/roles-game-options/werewolf-game-options/werewolf-game-options.schema.constants.ts
@@ -1,0 +1,25 @@
+import { DEFAULT_GAME_OPTIONS } from "@/modules/game/constants/game-options/game-options.constants";
+import type { WerewolfGameOptions } from "@/modules/game/schemas/game-options/roles-game-options/werewolf-game-options/werewolf-game-options.schema";
+import { convertMongoosePropOptionsToApiPropertyOptions } from "@/shared/api/helpers/api.helpers";
+import type { MongoosePropOptions } from "@/shared/mongoose/types/mongoose.types";
+import type { ApiPropertyOptions } from "@nestjs/swagger";
+import type { ReadonlyDeep } from "type-fest";
+
+const WEREWOLF_GAME_OPTIONS_FIELDS_SPECS = {
+  canEatEachOther: {
+    required: true,
+    default: DEFAULT_GAME_OPTIONS.roles.werewolf.canEatEachOther,
+  },
+} as const satisfies Record<keyof WerewolfGameOptions, MongoosePropOptions>;
+
+const WEREWOLF_GAME_OPTIONS_API_PROPERTIES: ReadonlyDeep<Record<keyof WerewolfGameOptions, ApiPropertyOptions>> = {
+  canEatEachOther: {
+    description: "Whether the `werewolves` can eat each other or not. It's not possible for an alone `werewolf` to eat himself if set to true.",
+    ...convertMongoosePropOptionsToApiPropertyOptions(WEREWOLF_GAME_OPTIONS_FIELDS_SPECS.canEatEachOther),
+  },
+};
+
+export {
+  WEREWOLF_GAME_OPTIONS_API_PROPERTIES,
+  WEREWOLF_GAME_OPTIONS_FIELDS_SPECS,
+};

--- a/src/modules/game/schemas/game-options/roles-game-options/werewolf-game-options/werewolf-game-options.schema.ts
+++ b/src/modules/game/schemas/game-options/roles-game-options/werewolf-game-options/werewolf-game-options.schema.ts
@@ -1,0 +1,23 @@
+import { WEREWOLF_GAME_OPTIONS_API_PROPERTIES, WEREWOLF_GAME_OPTIONS_FIELDS_SPECS } from "@/modules/game/schemas/game-options/roles-game-options/werewolf-game-options/werewolf-game-options.schema.constants";
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { ApiProperty, type ApiPropertyOptions } from "@nestjs/swagger";
+import { Expose } from "class-transformer";
+
+@Schema({
+  versionKey: false,
+  id: false,
+  _id: false,
+})
+class WerewolfGameOptions {
+  @ApiProperty(WEREWOLF_GAME_OPTIONS_API_PROPERTIES.canEatEachOther as ApiPropertyOptions)
+  @Prop(WEREWOLF_GAME_OPTIONS_FIELDS_SPECS.canEatEachOther)
+  @Expose()
+  public canEatEachOther: boolean;
+}
+
+const WEREWOLF_GAME_OPTIONS_SCHEMA = SchemaFactory.createForClass(WerewolfGameOptions);
+
+export {
+  WerewolfGameOptions,
+  WEREWOLF_GAME_OPTIONS_SCHEMA,
+};

--- a/tests/acceptance/features/game/data/game-options/werewolf-can-eat-each-other-option.json
+++ b/tests/acceptance/features/game/data/game-options/werewolf-can-eat-each-other-option.json
@@ -1,0 +1,7 @@
+{
+  "roles": {
+    "werewolf": {
+      "canEatEachOther": true
+    }
+  }
+}

--- a/tests/acceptance/features/game/features/role/big-bad-wolf.feature
+++ b/tests/acceptance/features/game/features/role/big-bad-wolf.feature
@@ -183,6 +183,51 @@ Feature: 🐺👹 Big Bad Wolf role
     And the request exception message should be "Bad game play payload"
     And the request exception error should be "Big bad wolf can't eat this target"
 
+  Scenario: 🐺👹Big Bad Wolf can eat another wolf with right option
+    Given a created game with options described in file no-sheriff-option.json, werewolf-can-eat-each-other-option.json and with the following players
+      | name   | role         |
+      | JH     | werewolf     |
+      | JB     | werewolf     |
+      | Olivia | big-bad-wolf |
+      | Thomas | villager     |
+      | Babou  | villager     |
+    Then the game's current play should be werewolves to eat
+
+    When the werewolves eat the player named Olivia
+    Then the game's current play should be big-bad-wolf to eat
+    And the game's current play source should have the following interactions
+      | type | source       | minBoundary | maxBoundary |
+      | eat  | big-bad-wolf | 1           | 1           |
+    And the game's current play source interaction with type eat should have the following eligible targets
+      | name   |
+      | JH     |
+      | JB     |
+      | Thomas |
+      | Babou  |
+
+    When the big bad wolf eats the player named JB
+    Then the request should have succeeded with status code 200
+    And the player named JB should be murdered by big-bad-wolf from eaten
+    And the player named Olivia should be murdered by werewolves from eaten
+
+  Scenario: 🐺👹Big Bad Wolf can't eat himself if he's the last alive werewolf with cannibalism option
+    Given a created game with options described in file no-sheriff-option.json, werewolf-can-eat-each-other-option.json and with the following players
+      | name   | role         |
+      | JB     | werewolf     |
+      | Olivia | big-bad-wolf |
+      | Thomas | villager     |
+      | Babou  | villager     |
+    Then the game's current play should be werewolves to eat
+
+    When the werewolves eat the player named JB
+    Then the game's current play should be big-bad-wolf to eat
+
+    When the big bad wolf eats the player named Olivia
+    Then the request should have failed with status code 400
+    And the request exception status code should be 400
+    And the request exception message should be "Bad game play payload"
+    And the request exception error should be "Big bad wolf can't eat this target"
+
   Scenario: 🐺👹Big Bad Wolf can't eat more than one target
     Given a created game with options described in file no-sheriff-option.json and with the following players
       | name    | role         |

--- a/tests/acceptance/features/game/features/role/werewolf.feature
+++ b/tests/acceptance/features/game/features/role/werewolf.feature
@@ -91,6 +91,62 @@ Feature: 🐺 Werewolf role
     And the request exception message should be "Bad game play payload"
     And the request exception error should be "Werewolves can't eat this target"
 
+  Scenario: 🐺 Werewolves can eat another wolf with right option
+    Given a created game with options described in file no-sheriff-option.json, werewolf-can-eat-each-other-option.json and with the following players
+      | name    | role     |
+      | Antoine | villager |
+      | Juju    | villager |
+      | Doudou  | werewolf |
+      | Thom    | werewolf |
+    Then the game's current play should be werewolves to eat
+    And the game's current play source should have the following interactions
+      | type | source     | minBoundary | maxBoundary |
+      | eat  | werewolves | 1           | 1           |
+    And the game's current play source interaction with type eat should have the following eligible targets
+      | name    |
+      | Antoine |
+      | Juju    |
+      | Doudou  |
+      | Thom    |
+
+    When the werewolves eat the player named Thom
+    Then the player named Thom should be murdered by werewolves from eaten
+
+  Scenario: 🐺 Werewolves can't eat himself if he is the last werewolf alive with cannibalism option
+    Given a created game with options described in file no-sheriff-option.json, werewolf-can-eat-each-other-option.json and with the following players
+      | name    | role     |
+      | Antoine | villager |
+      | Juju    | villager |
+      | Doudou  | werewolf |
+      | Thom    | werewolf |
+    Then the game's current play should be werewolves to eat
+    And the game's current play source interaction with type eat should have the following eligible targets
+      | name    |
+      | Antoine |
+      | Juju    |
+      | Doudou  |
+      | Thom    |
+
+    When the werewolves eat the player named Doudou
+    Then the player named Doudou should be murdered by werewolves from eaten
+    And the game's current play should be survivors to bury-dead-bodies
+
+    When the survivors bury dead bodies
+    Then the game's current play should be survivors to vote
+
+    When the player or group skips his turn
+    Then the game's current play should be werewolves to eat
+    And the game's current play source interaction with type eat should have the following eligible targets
+      | name    |
+      | Antoine |
+      | Juju    |
+
+    When the werewolves eat the player named Thom
+    Then the request should have failed with status code 400
+    And the request exception status code should be 400
+    And the request exception message should be "Bad game play payload"
+    And the request exception error should be "Werewolves can't eat this target"
+
   Scenario: 🐺 Werewolves can't skip their turn
     Given a created game with options described in file no-sheriff-option.json and with the following players
       | name    | role     |

--- a/tests/e2e/specs/modules/game/controllers/game.controller.e2e-spec.ts
+++ b/tests/e2e/specs/modules/game/controllers/game.controller.e2e-spec.ts
@@ -997,6 +997,7 @@ describe("Game Controller", () => {
             hasDoubledVote: false,
             mustSettleTieInVotes: false,
           },
+          werewolf: { canEatEachOther: true },
           bigBadWolf: { isPowerlessIfWerewolfDies: false },
           whiteWerewolf: { wakingUpInterval: 5 },
           seer: {
@@ -1336,6 +1337,7 @@ describe("Game Controller", () => {
         currentPlay,
         upcomingPlays: [createFakeGamePlayWerewolvesEat()],
         players,
+        options: DEFAULT_GAME_OPTIONS,
       });
       await models.game.create(game);
       const payload = createFakeMakeGamePlayDto({ targets: [{ playerId: players[0]._id }] });
@@ -1367,6 +1369,7 @@ describe("Game Controller", () => {
           players[2],
           players[3],
         ],
+        options: DEFAULT_GAME_OPTIONS,
       });
       const response = await app.inject({
         method: "POST",

--- a/tests/factories/game/dto/create-game/create-game-options/create-roles-game-options/create-roles-game-options.dto.factory.ts
+++ b/tests/factories/game/dto/create-game/create-game-options/create-roles-game-options/create-roles-game-options.dto.factory.ts
@@ -1,3 +1,4 @@
+import { CreateWerewolfGameOptionsDto } from "@/modules/game/dto/create-game/create-game-options/create-roles-game-options/create-werewolf-game-options.dto";
 import { faker } from "@faker-js/faker";
 import { plainToInstance } from "class-transformer";
 
@@ -208,6 +209,13 @@ function createFakeCreateBigBadWolfGameOptionsDto(bigBadWolfOptions: Partial<Cre
   }, DEFAULT_PLAIN_TO_INSTANCE_OPTIONS);
 }
 
+function createFakeCreateWerewolfGameOptionsDto(werewolfGameOptions: Partial<CreateWerewolfGameOptionsDto> = {}, override: object = {}): CreateWerewolfGameOptionsDto {
+  return plainToInstance(CreateWerewolfGameOptionsDto, {
+    canEatEachOther: werewolfGameOptions.canEatEachOther ?? faker.datatype.boolean(),
+    ...override,
+  }, DEFAULT_PLAIN_TO_INSTANCE_OPTIONS);
+}
+
 function createFakeCreateSheriffElectionGameOptionsDto(
   sheriffElectionGameOptions: Partial<CreateSheriffElectionGameOptionsDto> = {},
   override: object = {},
@@ -234,6 +242,7 @@ function createFakeRolesGameOptionsDto(rolesGameOptions: Partial<CreateRolesGame
     doSkipCallIfNoTarget: rolesGameOptions.doSkipCallIfNoTarget ?? faker.datatype.boolean(),
     areRevealedOnDeath: rolesGameOptions.areRevealedOnDeath ?? faker.datatype.boolean(),
     sheriff: createFakeCreateSheriffGameOptionsDto(rolesGameOptions.sheriff),
+    werewolf: createFakeCreateWerewolfGameOptionsDto(rolesGameOptions.werewolf),
     bigBadWolf: createFakeCreateBigBadWolfGameOptionsDto(rolesGameOptions.bigBadWolf),
     whiteWerewolf: createFakeCreateWhiteWerewolfGameOptionsDto(rolesGameOptions.whiteWerewolf),
     seer: createFakeCreateSeerGameOptionsDto(rolesGameOptions.seer),
@@ -282,6 +291,7 @@ export {
   createFakeCreateCupidGameOptionsDto,
   createFakeCreateWhiteWerewolfGameOptionsDto,
   createFakeCreateBigBadWolfGameOptionsDto,
+  createFakeCreateWerewolfGameOptionsDto,
   createFakeCreateSheriffElectionGameOptionsDto,
   createFakeCreateSheriffGameOptionsDto,
   createFakeRolesGameOptionsDto,

--- a/tests/factories/game/schemas/game-options/game-roles-options/game-roles-options.schema.factory.ts
+++ b/tests/factories/game/schemas/game-options/game-roles-options/game-roles-options.schema.factory.ts
@@ -1,3 +1,4 @@
+import { WerewolfGameOptions } from "@/modules/game/schemas/game-options/roles-game-options/werewolf-game-options/werewolf-game-options.schema";
 import { faker } from "@faker-js/faker";
 import { plainToInstance } from "class-transformer";
 
@@ -196,6 +197,13 @@ function createFakeBigBadWolfGameOptions(bigBadWolfOptions: Partial<BigBadWolfGa
   }, DEFAULT_PLAIN_TO_INSTANCE_OPTIONS);
 }
 
+function createFakeWerewolfGameOptions(werewolfGameOptions: Partial<WerewolfGameOptions> = {}, override: object = {}): WerewolfGameOptions {
+  return plainToInstance(WerewolfGameOptions, {
+    canEatEachOther: werewolfGameOptions.canEatEachOther ?? faker.datatype.boolean(),
+    ...override,
+  }, DEFAULT_PLAIN_TO_INSTANCE_OPTIONS);
+}
+
 function createFakeSheriffElectionGameOptions(sheriffElectionGameOptions: Partial<SheriffElectionGameOptions> = {}, override: object = {}): SheriffElectionGameOptions {
   return plainToInstance(SheriffElectionGameOptions, {
     turn: sheriffElectionGameOptions.turn ?? faker.number.int({ min: 1 }),
@@ -219,6 +227,7 @@ function createFakeRolesGameOptions(rolesGameOptions: Partial<RolesGameOptions> 
     doSkipCallIfNoTarget: rolesGameOptions.doSkipCallIfNoTarget ?? faker.datatype.boolean(),
     areRevealedOnDeath: rolesGameOptions.areRevealedOnDeath ?? faker.datatype.boolean(),
     sheriff: createFakeSheriffGameOptions(rolesGameOptions.sheriff),
+    werewolf: createFakeWerewolfGameOptions(rolesGameOptions.werewolf),
     bigBadWolf: createFakeBigBadWolfGameOptions(rolesGameOptions.bigBadWolf),
     whiteWerewolf: createFakeWhiteWerewolfGameOptions(rolesGameOptions.whiteWerewolf),
     seer: createFakeSeerGameOptions(rolesGameOptions.seer),
@@ -267,6 +276,7 @@ export {
   createFakeCupidLoversGameOptions,
   createFakeWhiteWerewolfGameOptions,
   createFakeBigBadWolfGameOptions,
+  createFakeWerewolfGameOptions,
   createFakeSheriffElectionGameOptions,
   createFakeSheriffGameOptions,
   createFakeRolesGameOptions,

--- a/tests/unit/specs/modules/game/providers/services/game-play/game-play-augmenter.service.spec.ts
+++ b/tests/unit/specs/modules/game/providers/services/game-play/game-play-augmenter.service.spec.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_GAME_OPTIONS } from "@/modules/game/constants/game-options/game-options.constants";
 import type { TestingModule } from "@nestjs/testing";
 import { Test } from "@nestjs/testing";
 
@@ -88,6 +89,7 @@ describe("Game Play Augmenter Service", () => {
     };
     gameHelper: {
       getEligibleWerewolvesTargets: jest.SpyInstance;
+      getEligibleBigBadWolfTargets: jest.SpyInstance;
       getEligibleWhiteWerewolfTargets: jest.SpyInstance;
       getEligiblePiedPiperTargets: jest.SpyInstance;
       getEligibleCupidTargets: jest.SpyInstance;
@@ -169,6 +171,7 @@ describe("Game Play Augmenter Service", () => {
       },
       gameHelper: {
         getEligibleWerewolvesTargets: jest.spyOn(GameHelper, "getEligibleWerewolvesTargets"),
+        getEligibleBigBadWolfTargets: jest.spyOn(GameHelper, "getEligibleBigBadWolfTargets"),
         getEligibleWhiteWerewolfTargets: jest.spyOn(GameHelper, "getEligibleWhiteWerewolfTargets"),
         getEligiblePiedPiperTargets: jest.spyOn(GameHelper, "getEligiblePiedPiperTargets"),
         getEligibleCupidTargets: jest.spyOn(GameHelper, "getEligibleCupidTargets"),
@@ -845,7 +848,7 @@ describe("Game Play Augmenter Service", () => {
         createFakeWerewolfAlivePlayer(),
       ];
       const game = createFakeGame({ players });
-      mocks.gameHelper.getEligibleWerewolvesTargets.mockReturnValueOnce([
+      mocks.gameHelper.getEligibleBigBadWolfTargets.mockReturnValueOnce([
         players[0],
         players[1],
       ]);
@@ -869,8 +872,11 @@ describe("Game Play Augmenter Service", () => {
         createFakeVillagerAlivePlayer(),
         createFakeVillagerAlivePlayer(),
       ];
-      const game = createFakeGame({ players });
-      mocks.gameHelper.getEligibleWerewolvesTargets.mockReturnValueOnce([]);
+      const game = createFakeGame({
+        players,
+        options: DEFAULT_GAME_OPTIONS,
+      });
+      mocks.gameHelper.getEligibleBigBadWolfTargets.mockReturnValueOnce([]);
 
       expect(services.gamePlayAugmenter["getBigBadWolfGamePlaySourceInteractions"](game)).toStrictEqual<GamePlaySourceInteraction[]>([]);
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new game option for werewolves, allowing for specific behaviors like preventing them from eating each other.
  - Added specific game mechanics for the Big Bad Wolf role.
  
- **Bug Fixes**
  - Updated werewolf and Big Bad Wolf target eligibility logic to ensure correct game behavior.

- **Tests**
  - Expanded test coverage to include new werewolf and Big Bad Wolf behaviors.
  - Added new end-to-end and unit tests for werewolf options and behaviors.

- **Documentation**
  - Updated game configuration schemas and API properties to reflect new werewolf options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->