### PR TITLE
fix(scandalmonger): remove mark after first vote

### DIFF
--- a/src/modules/game/providers/services/game-play/game-play-maker/game-play-maker.service.ts
+++ b/src/modules/game/providers/services/game-play/game-play-maker/game-play-maker.service.ts
@@ -197,6 +197,10 @@ export class GamePlayMakerService {
       const gamePlayStutteringJudgeRequestsAnotherVote = createGamePlayStutteringJudgeRequestsAnotherVote();
       clonedGame = prependUpcomingPlayInGame(gamePlayStutteringJudgeRequestsAnotherVote, clonedGame) as GameWithCurrentPlay;
     }
+    const scandalmongerMarkedPlayer = getPlayerWithActiveAttributeName(clonedGame, "scandalmonger-marked");
+    if (scandalmongerMarkedPlayer) {
+      clonedGame = removePlayerAttributeByNameInGame(scandalmongerMarkedPlayer._id, clonedGame, "scandalmonger-marked") as GameWithCurrentPlay;
+    }
     if (nominatedPlayers.length > 1) {
       return this.handleTieInVotes(clonedGame, nominatedPlayers);
     }

--- a/tests/acceptance/features/game/features/role/scandalmonger.feature
+++ b/tests/acceptance/features/game/features/role/scandalmonger.feature
@@ -214,3 +214,45 @@ Feature: 🐦‍⬛ Scandalmonger role
     And the request exception status code should be 400
     And the request exception message should be "Bad game play payload"
     And the request exception error should be "There are too much targets for this current game's state"
+
+  Scenario: 🐦‍⬛ Scandalmonger's mark is removed after the first vote
+    Given a created game with options described in file no-sheriff-option.json and with the following players
+      | name    | role             |
+      | Antoine | scandalmonger    |
+      | Olivia  | werewolf         |
+      | JB      | villager         |
+      | Camille | villager         |
+      | Thomas  | stuttering-judge |
+      | Pedro   | villager         |
+    Then the game's current play should be scandalmonger to mark
+
+    When the scandalmonger marks the player named JB
+    Then the player named JB should have the active scandalmonger-marked from scandalmonger attribute
+    And the game's current play should be werewolves to eat
+
+    When the werewolves eat the player named Camille
+    Then the player named Camille should be murdered by werewolves from eaten
+    And the game's current play should be survivors to bury-dead-bodies
+
+    When the survivors bury dead bodies
+    Then the game's current play should be survivors to vote
+
+    When the survivors vote with the following votes
+      | voter   | target |
+      | Olivia  | Pedro  |
+      | Antoine | Pedro  |
+      | Thomas  | Pedro  |
+    Then the player named JB should not have the active scandalmonger-marked from scandalmonger attribute
+    And the game's current play should be survivors to bury-dead-bodies
+
+    When the survivors bury dead bodies
+    Then the game's current play should be stuttering-judge to request-another-vote
+
+    When the stuttering judge requests another vote
+    Then the game's current play should be survivors to vote
+
+    When the survivors vote with the following votes
+      | voter  | target  |
+      | Thomas | Antoine |
+    Then the player named JB should not have the active scandalmonger-marked from scandalmonger attribute
+    And the player named Antoine should be murdered by survivors from vote


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new mechanics for handling the "scandalmonger" player attribute during gameplay, enhancing responsiveness to player states.
	- Added a new scenario detailing the removal of the Scandalmonger's mark after the first vote, enriching gameplay dynamics.

- **Tests**
	- Enhanced test coverage for the `survivorsVote` functionality, verifying the removal of the scandalmonger mark during voting processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->