### PR TITLE
fix(brothers-sisters): not called if powerless

### DIFF
--- a/.run/Two Sisters Role.run.xml
+++ b/.run/Two Sisters Role.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Two Sister Role" type="cucumber.js" factoryName="Cucumber.js" folderName="Tags">
+  <configuration default="false" name="Two Sisters Role" type="cucumber.js" factoryName="Cucumber.js" folderName="Tags">
     <option name="myFilePath" value="$PROJECT_DIR$/tests/acceptance" />
     <option name="myNameFilter" value="" />
     <option name="cucumberJsArguments" value="--config config/cucumber/cucumber.json --tags @two-sisters-role --parallel 1" />

--- a/src/modules/game/providers/services/game-play/game-play.service.ts
+++ b/src/modules/game/providers/services/game-play/game-play.service.ts
@@ -307,8 +307,9 @@ export class GamePlayService {
     }
     const threeBrothersPlayers = getPlayersWithCurrentRole(game, "three-brothers");
     const minimumBrotherCountToCall = 2;
+    const aliveAndPowerfulBrothers = threeBrothersPlayers.filter(brother => isPlayerAliveAndPowerful(brother, game));
 
-    return shouldThreeBrothersBeCalledOnCurrentTurn && threeBrothersPlayers.filter(brother => brother.isAlive).length >= minimumBrotherCountToCall;
+    return shouldThreeBrothersBeCalledOnCurrentTurn && aliveAndPowerfulBrothers.length >= minimumBrotherCountToCall;
   }
 
   private isTwoSistersGamePlaySuitableForCurrentPhase(game: CreateGameDto | Game): boolean {
@@ -319,7 +320,7 @@ export class GamePlayService {
     }
     const twoSistersPlayers = getPlayersWithCurrentRole(game, "two-sisters");
 
-    return shouldTwoSistersBeCalledOnCurrentTurn && twoSistersPlayers.length > 0 && twoSistersPlayers.every(sister => sister.isAlive);
+    return shouldTwoSistersBeCalledOnCurrentTurn && twoSistersPlayers.length > 0 && twoSistersPlayers.every(sister => isPlayerAliveAndPowerful(sister, game));
   }
 
   private async isCupidGamePlaySuitableForCurrentPhase(game: CreateGameDto | Game): Promise<boolean> {

--- a/tests/acceptance/features/game/features/role/three-brothers.feature
+++ b/tests/acceptance/features/game/features/role/three-brothers.feature
@@ -117,3 +117,26 @@ Feature: 👨‍👨‍👦 Three Brothers role
       | name    |
       | Antoine |
       | Olivia  |
+
+  Scenario: 👨‍👨‍👦 Three Brothers are not called if one of them is powerless
+    Given a created game with options described in file no-sheriff-option.json and with the following players
+      | name    | role           |
+      | Antoine | three-brothers |
+      | Olivia  | three-brothers |
+      | Thomas  | three-brothers |
+      | JB      | werewolf       |
+      | Maxime  | angel          |
+      | Julien  | elder          |
+    Then the game's current play should be survivors to vote
+    And the game's current play should have the following causes
+      | cause          |
+      | angel-presence |
+
+    When the survivors vote with the following votes
+      | voter   | target |
+      | Antoine | Julien |
+    Then the player named Julien should be murdered by survivors from vote
+    And the game's current play should be survivors to bury-dead-bodies
+
+    When the survivors bury dead bodies
+    Then the game's current play should be werewolves to eat

--- a/tests/acceptance/features/game/features/role/two-sisters.feature
+++ b/tests/acceptance/features/game/features/role/two-sisters.feature
@@ -105,3 +105,26 @@ Feature: 👯‍ Two sisters role
 
     When the player or group skips his turn
     Then the game's current play should be two-sisters to meet-each-other
+
+  Scenario: 👯‍ Two sisters are not called if one of them is powerless
+    Given a created game with options described in file no-sheriff-option.json and with the following players
+      | name    | role        |
+      | Antoine | two-sisters |
+      | Olivia  | two-sisters |
+      | JB      | werewolf    |
+      | Thomas  | angel       |
+      | Maxime  | elder       |
+      | Julien  | villager    |
+    Then the game's current play should be survivors to vote
+    And the game's current play should have the following causes
+      | cause          |
+      | angel-presence |
+
+    When the survivors vote with the following votes
+      | voter   | target |
+      | Antoine | Maxime |
+    Then the player named Maxime should be murdered by survivors from vote
+    And the game's current play should be survivors to bury-dead-bodies
+
+    When the survivors bury dead bodies
+    Then the game's current play should be werewolves to eat

--- a/tests/unit/specs/modules/game/providers/services/game-history/game-history-record-to-insert-generator.service.spec.ts
+++ b/tests/unit/specs/modules/game/providers/services/game-history/game-history-record-to-insert-generator.service.spec.ts
@@ -702,6 +702,7 @@ describe("Game History Record To Insert Generator Service", () => {
   describe("generateCurrentGameHistoryRecordPlayToInsert", () => {
     beforeEach(() => {
       mocks.gameHistoryRecordToInsertGeneratorService.generateCurrentGameHistoryRecordPlaySourceToInsert = jest.spyOn(services.gameHistoryRecordToInsertGenerator as unknown as { generateCurrentGameHistoryRecordPlaySourceToInsert }, "generateCurrentGameHistoryRecordPlaySourceToInsert").mockImplementation();
+      mocks.gameHistoryRecordToInsertGeneratorService.generateCurrentGameHistoryRecordPlayTargetsToInsert = jest.spyOn(services.gameHistoryRecordToInsertGenerator as unknown as { generateCurrentGameHistoryRecordPlayTargetsToInsert }, "generateCurrentGameHistoryRecordPlayTargetsToInsert").mockImplementation();
     });
 
     it("should generate current game history record play to insert when called.", () => {
@@ -715,6 +716,7 @@ describe("Game History Record To Insert Generator Service", () => {
       });
       const expectedGameHistoryRecordPlaySource = { name: undefined, players: undefined };
       mocks.gameHistoryRecordToInsertGeneratorService.generateCurrentGameHistoryRecordPlaySourceToInsert.mockReturnValue(expectedGameHistoryRecordPlaySource);
+      mocks.gameHistoryRecordToInsertGeneratorService.generateCurrentGameHistoryRecordPlayTargetsToInsert.mockReturnValue(play.targets);
       const expectedGameHistoryRecordPlay = createFakeGameHistoryRecordPlay({
         type: game.currentPlay.type,
         action: game.currentPlay.action,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced player role logic for "Three Brothers" and "Two Sisters," ensuring that players must be both alive and powerful for their roles to activate.
	- New acceptance test scenarios for the "Three Brothers" and "Two Sisters" roles, covering edge cases when players are powerless.

- **Bug Fixes**
	- Corrected the naming of the "Two Sisters Role" in configuration for clarity.

- **Tests**
	- Improved test coverage with new scenarios detailing game logic changes based on player power and interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->